### PR TITLE
Fix permission denied or shell issues

### DIFF
--- a/monalize.go
+++ b/monalize.go
@@ -71,7 +71,7 @@ func Color(colorString string) func(...interface{}) string {
 
 func currentlog(db_uri, logpath string) { // func make log files with slow queries and send files to ftp server. Clear history.
 	fmt.Println(Info("Search slow query..."))
-	err, out, errout := Shellout("mongo " + db_uri + " --eval " + `'db.currentOp({"secs_running": {$gte: 1}})'`)
+	err, out, errout := Shellout("mongo '" + db_uri + "' --eval " + `'db.currentOp({"secs_running": {$gte: 1}})'`)
 	if err != nil {
 		log.Printf("error: %v\n", err)
 	}


### PR DESCRIPTION
This change fixes issue #1 which was caused by the db_uri not being escaped when called via the shell. Special characters such as ! and $ may cause the shell to interpret them in a special way and by escaping them we fix that issue.